### PR TITLE
16조 - fix : duplicate keypress

### DIFF
--- a/frontend/components/chat/ChatInput.js
+++ b/frontend/components/chat/ChatInput.js
@@ -307,6 +307,11 @@ const ChatInput = forwardRef(({
   }, [message, setMessage, setShowMentionList, messageInputRef]);
 
   const handleKeyDown = useCallback((e) => {
+
+    if (e.nativeEvent.isComposing) {
+      return;
+    }
+    
     if (showMentionList) {
       const participants = getFilteredParticipants(room); // room 객체 전달
       const participantsCount = participants.length;


### PR DESCRIPTION
### PR: 한글 입력 시 중복 전송 문제 수정

한글 입력 시 `Enter` 키 이벤트가 두 번 처리되어 메시지가 중복 전송되는 문제를 해결했습니다.

####  주요 변경사항

* `ChatInput.js`의 `handleKeyDown` 함수에 `e.nativeEvent.isComposing` 체크 로직 추가
* 한글 조합 중(`isComposing === true`)일 때는 `Enter` 키 입력을 무시하여 중복 전송 방지

####  기대 효과

* 한글 입력 후 `Enter` 키 입력 시 메시지가 **정상적으로 한 번만 전송**
* 사용자 입력 경험 개선

<img width="378" height="716" alt="image" src="https://github.com/user-attachments/assets/1eca1145-1c3c-4e3b-8397-b7d89fa827b4" />

