### PR TITLE
4조-fix: chat 한글 중복 입력 버그 픽스

### DIFF
--- a/frontend/components/chat/ChatInput.js
+++ b/frontend/components/chat/ChatInput.js
@@ -343,6 +343,7 @@ const ChatInput = forwardRef(({
           return;
       }
     } else if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.nativeEvent.isComposing) return
       e.preventDefault();
       if (message.trim() || files.length > 0) {
         handleSubmit(e);


### PR DESCRIPTION
### 문제
- 한글 입력 시 마지막 글자가 중복 생성되는 문제
- 숫자, 영어는 해당되지 않음

### 원인
- 한글은 조합문자로, 문자의 조합과정에서 마지막 문자의 입력이 완료되었는지 구분되는지 못해서 중복 발생

### 해결 방법
- `isComposing`을 통해 입력 과정의 경우 return하도록 보안로직 추가