### PR TITLE
fix: 읽음 처리 svg 중복 렌더링

### DIFF
--- a/frontend/components/chat/ReadStatus.js
+++ b/frontend/components/chat/ReadStatus.js
@@ -182,7 +182,6 @@ const ReadStatus = ({
         <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
           <div style={{ display: 'flex', alignItems: 'center' }}>
             <ConfirmOutlineIcon size={12} style={{ color: 'var(--vapor-color-success)' }} />
-            <ConfirmOutlineIcon size={12} style={{ color: 'var(--vapor-color-success)', marginLeft: '-6px' }} />
           </div>
           <Text typography="caption" style={{ fontSize: '0.65rem', color: 'var(--vapor-color-text-muted)' }}>모두 읽음</Text>
         </div>


### PR DESCRIPTION
### 문제
- 읽음 처리 체크 svg가 2개 존재하는 문제 

### 해결 방법
- 읽음 처리 체크 svg가 margin 6px 차이로 2개 존재했기 때문에, 1개를 제거했다.