### PR TITLE
fix: input내 마크다운(ol, li) 스타일이 보이지 않는 문제 해결

### DIFF
--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -506,6 +506,13 @@ body {
   margin: var(--vapor-space-050) 0;
 }
 
+.md-ol {
+  list-style-type: decimal;
+}
+.md-ul {
+  list-style-type: '· ';
+}
+
 /* Code blocks */
 .message-content pre[class*="language-"] {
   margin: var(--vapor-space-100) 0;


### PR DESCRIPTION
### 문제
- 채팅 내 마크다운으로 생성했지만, 들여쓰기만되고, 스타일이 보이지 않음

### 원인
- 설정된 스타일이 `global.css` 파일에 존재하지 않았음

### 해결 방법
- 스타일 파일에, `md-ol, md-ul` 설정 추가