### PR TITLE
4조 - fix: 비밀번호 수정 에러 해결

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -130,12 +130,15 @@ exports.getProfile = async (req, res) => {
 exports.updateProfile = async (req, res) => {
   try {
     const { name } = req.body;
+    const { newPassword } = req.body;
 
-    if (!name || name.trim().length === 0) {
-      return res.status(400).json({
-        success: false,
-        message: '이름을 입력해주세요.'
-      });
+    if (name) {
+      if (name.trim().length === 0) {
+        return res.status(400).json({
+          success: false,
+          message: '이름을 입력해주세요.'
+        });
+      }
     }
 
     const user = await User.findById(req.user.id);
@@ -146,7 +149,11 @@ exports.updateProfile = async (req, res) => {
       });
     }
 
-    user.name = name.trim();
+    user.name = name ? name.trim() : user.name;
+    if (newPassword) {
+      user.password = newPassword;
+    }
+
     await user.save();
 
     res.json({


### PR DESCRIPTION
### 문제
- 비밀번호 변경 시, '닉네임이 없습니다' 오류가 발생

### 해결 방법
- 비밀번호 변경에 요구되지 않는 닉네임 변경 요청을 제거하고, 사용자 프로필 업데이트 API를 전달받은 값에 따라 수정되도록 변경