### PR TITLE
4조 - fix: 방 진입 시 비밀번호 미입력에 대한 예외 처리 추가

### DIFF
--- a/backend/routes/api/rooms.js
+++ b/backend/routes/api/rooms.js
@@ -275,6 +275,12 @@ router.post('/:roomId/join', auth, async (req, res) => {
 
     // 비밀번호 확인
     if (room.hasPassword) {
+      if (!password) {
+        return res.status(400).json({
+          success: false,
+          message: '비밀번호를 입력해주세요.'
+        });
+      }
       const isPasswordValid = await room.checkPassword(password);
       if (!isPasswordValid) {
         return res.status(401).json({


### PR DESCRIPTION
## 문제

- 비밀번호가 설정된 방에 비밀번호 없이 접근 시 `checkPassword(undefined)` 호출로 인해 런타임 오류 또는 부정확한 응답 메시지 발생


## 변경 내용

- 비밀번호 미입력 시 즉시 `400 Bad Request` 응답 반환 로직 추가

## 필요성
- 런타임 오류 방지 (`undefined`를 비교 함수에 전달해 생기는 TypeError 런타임 오류)
- 서버 안정성 확보
- 비밀번호 미입력과 오입력을 구분한 명확한 피드백 제공으로 사용자 경험 개선

## 테스트

* 비밀번호가 있는 방에서 비밀번호 없이 진입 시 400 에러 응답 확인
* 잘못된 비밀번호 → 401 에러
* 올바른 비밀번호 → 정상 진입
